### PR TITLE
Add lint against shadowing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,10 +2,16 @@
   "plugins": ["prettier"],
   "extends": ["prettier"],
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "no-shadow": [
+      "error",
+      {
+        "builtinGlobals": true
+      }
+    ]
   },
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 8,
     "sourceType": "module"
   }
 }


### PR DESCRIPTION
Shadowing is a bad idea in a language with as loose types as js.