### PR TITLE
Add full source maps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,5 +87,5 @@ module.exports = {
       NODE_ENV: 'development', // use 'development' unless process.env.NODE_ENV is defined
     }),
   ],
-  devtool: 'cheap-module-source-remap',
+  devtool: 'source-map',
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,5 +87,5 @@ module.exports = {
       NODE_ENV: 'development', // use 'development' unless process.env.NODE_ENV is defined
     }),
   ],
-  devtool: 'source-map',
+  devtool: 'cheap-module-eval-source-map',
 };


### PR DESCRIPTION
Fixes #105

There are multiple levels of source mapping available. This one opts for
a full source map at the potential cost of build time. If build times
become a concern, this can be changed.