### PR TITLE
Try 'eth_requestAccounts' as a workaround for enabling privacy mode

### DIFF
--- a/src/lib/donate.ts
+++ b/src/lib/donate.ts
@@ -20,8 +20,18 @@ export default class Donate {
     await import('bn.js');
     web3 = new Web3(web3Provider);
 
-    //return web3.eth.net.getId();
-    return this.getNetId();
+    return new Promise((res, rej) => {
+      console.log('init promise');
+      web3Provider.send({ method: 'eth_requestAccounts' }, (err, addrs) => {
+        if (err) {
+          console.log('user denied metamask permission', err);
+          return rej(err);
+        }
+
+        console.log('addrs', addrs);
+        return res(this.getNetId());
+      });
+    });
   }
 
   async getNetId(): Promise<number> {


### PR DESCRIPTION
Doesn't seem to work. What happens:

'init promise' is always printed.  
'addrs' is printed if privacy mode is off.
Neither 'addrs' nor 'user denied metamask permission' are printed when privacy mode is on, and no popup (or anything special in the metamask window) shows.  
The permission popup does work for me on websites like gitcoin.